### PR TITLE
Add compatibility with manifest v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "linkding injector",
   "version": "1.2.0",
   "description": "Injects search results from the linkding bookmark service into search pages like google and duckduckgo",
@@ -14,7 +14,7 @@
   },
 
   "background": {
-    "scripts": ["build/background.js"]
+    "service_worker": "build/background.js"
   },
 
   "content_scripts": [
@@ -225,7 +225,14 @@
     "page": "options/index.html"
   },
 
-  "web_accessible_resources": ["icons/*.png", "icons/*.svg"],
+  "web_accessible_resources": [{
+    "resources": ["/icons/*.png", "/icons/*.svg"],
+    "matches": ["https://*/*", "http://*/*"]
+  }],
 
-  "permissions": ["https://*/*", "http://*/*"]
+  "permissions": [
+    "storage"
+  ],
+
+  "host_permissions": ["https://*/*", "http://*/*"]
 }

--- a/src/background.js
+++ b/src/background.js
@@ -13,19 +13,19 @@ function connected(p) {
 
   // When the content script sends the search term, search on linkding and
   // return results
-  portFromCS.onMessage.addListener(function (m) {
+  portFromCS.onMessage.addListener(async function (m) {
     if (m.action == "openOptions") {
       // Open the add on options if the user clicks on the options link in the
       // injected box
       openOptions();
-    } else if (isConfigurationComplete() == false) {
+    } else if (await isConfigurationComplete() == false) {
       portFromCS.postMessage({
         message:
           "Connection to your linkding instance is not configured yet! " +
           "Please configure the extension in the <a class='openOptions'>options</a>.",
       });
     } else {
-      let config = getConfiguration();
+      let config = await getConfiguration();
       // Configuration is complete, execute a search on linkding
       search(m.searchTerm, { limit: config.resultNum })
         .then((results) => {

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,4 +1,4 @@
-function isChrome() {
+export function isChrome() {
   return typeof chrome !== "undefined";
 }
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,7 +1,13 @@
+import { isChrome, getBrowser } from "./browser";
+
 const CONFIG_KEY = "ld_ext_config";
 
-export function getConfiguration() {
-  const configJson = localStorage.getItem(CONFIG_KEY);
+export async function getConfiguration() {
+  const configPromise = isChrome()
+    ? new Promise((resolve) => getBrowser().storage.local.get(CONFIG_KEY, resolve))
+    : getBrowser().storage.local.get(CONFIG_KEY);
+  const promiseResult = await configPromise;
+  const configJson = promiseResult && promiseResult[CONFIG_KEY];
   const config = configJson
     ? JSON.parse(configJson)
     : {
@@ -17,11 +23,11 @@ export function getConfiguration() {
 
 export function saveConfiguration(config) {
   const configJson = JSON.stringify(config);
-  localStorage.setItem(CONFIG_KEY, configJson);
+  getBrowser().storage.local.set({ [CONFIG_KEY]: configJson });
 }
 
-export function isConfigurationComplete() {
-  const config = getConfiguration();
+export async function isConfigurationComplete() {
+  const config = await getConfiguration();
 
   return config.baseUrl && config.token;
 }

--- a/src/linkding.js
+++ b/src/linkding.js
@@ -1,7 +1,7 @@
 import { getConfiguration } from "./configuration";
 
 export async function getTags() {
-  const configuration = getConfiguration();
+  const configuration = await getConfiguration();
 
   return fetch(`${configuration.baseUrl}/api/tags/?limit=1000`, {
     headers: {
@@ -16,7 +16,7 @@ export async function getTags() {
 }
 
 export async function search(text, options) {
-  const configuration = getConfiguration();
+  const configuration = await getConfiguration();
   const q = encodeURIComponent(text);
   const limit = options.limit || 100;
 

--- a/src/options.svelte
+++ b/src/options.svelte
@@ -11,8 +11,8 @@
   let isSuccess;
   let isError;
 
-  function init() {
-    const config = getConfiguration();
+  async function init() {
+    const config = await getConfiguration();
     baseUrl = config.baseUrl;
     token = config.token;
     resultNum = config.resultNum;


### PR DESCRIPTION
This pr will update the manifest to use V3 instead of V2 (the end is near: https://developer.chrome.com/blog/mv2-transition/) with all necessary code changes.

I did not test it in Firefox and `npx web-ext lint` breaks with manifest V3, that's the reason why marked it as draft.