### PR TITLE
Fix Signature Error and Refactor saveConfiguration

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -2,32 +2,32 @@ import { getStorage } from "./browser";
 
 const CONFIG_KEY = "ld_ext_config";
 
-export const getConfiguration = async () => {
+export async function getConfiguration() {
+  const DEFAULT_CONFIG = {
+    baseUrl: "",
+    token: "",
+    resultNum: 10,
+    openLinkType: "newTab",
+    themeGoogle: "auto",
+    themeDuckduckgo: "auto",
+    themeBrave: "auto",
+    themeSearx: "auto",
+  };
+
   return new Promise((resolve) => {
     getStorage().get(CONFIG_KEY, (data) => {
-      const config = JSON.parse(
-        data[CONFIG_KEY] || {
-          baseUrl: '',
-          token: '',
-          resultNum: 10,
-          openLinkType: 'newTab',
-          themeGoogle: 'auto',
-          themeDuckduckgo: 'auto',
-          themeBrave: 'auto',
-          themeSearx: 'auto',
-        }
-      )
-      resolve(config)
-    })
-  })
-}
+      const config = JSON.parse(data[CONFIG_KEY] || DEFAULT_CONFIG);
+      resolve(config);
+    });
+  });
+};
 
 export function saveConfiguration(config) {
   const configJson = JSON.stringify(config);
   getStorage().set({ [CONFIG_KEY]: configJson });
 }
 
-export const isConfigurationComplete = async () => {
-  const { baseUrl, token } = await getConfiguration()
-  return !!baseUrl && !!token
-}
+export async function isConfigurationComplete() {
+  const { baseUrl, token } = await getConfiguration();
+  return !!baseUrl && !!token;
+};

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -2,31 +2,24 @@ import { getStorage } from "./browser";
 
 const CONFIG_KEY = "ld_ext_config";
 
-export async function getConfiguration() {
-  let config = "";
-
-  const configJson = await getStorage().get(CONFIG_KEY);
-
-  if (
-    // if there is no saved configuration, save a default configuration
-    configJson &&
-    Object.keys(configJson).length === 0 &&
-    Object.getPrototypeOf(configJson) === Object.prototype
-  ) {
-    config = {
-      baseUrl: "",
-      token: "",
-      resultNum: 10,
-      openLinkType: "newTab",
-      themeGoogle: "auto",
-      themeDuckduckgo: "auto",
-      themeBrave: "auto",
-      themeSearx: "auto",
-    };
-  } else {
-    config = JSON.parse(configJson[CONFIG_KEY]);
-  }
-  return config;
+export const getConfiguration = async () => {
+  return new Promise((resolve) => {
+    getStorage().get(CONFIG_KEY, (data) => {
+      const config = JSON.parse(
+        data[CONFIG_KEY] || {
+          baseUrl: '',
+          token: '',
+          resultNum: 10,
+          openLinkType: 'newTab',
+          themeGoogle: 'auto',
+          themeDuckduckgo: 'auto',
+          themeBrave: 'auto',
+          themeSearx: 'auto',
+        }
+      )
+      resolve(config)
+    })
+  })
 }
 
 export function saveConfiguration(config) {
@@ -34,12 +27,7 @@ export function saveConfiguration(config) {
   getStorage().set({ [CONFIG_KEY]: configJson });
 }
 
-export async function isConfigurationComplete() {
-  const config = await getConfiguration();
-
-  if (config.baseUrl === "" || config.token === "") {
-    return false;
-  } else {
-    return true
-  }
+export const isConfigurationComplete = async () => {
+  const { baseUrl, token } = await getConfiguration()
+  return !!baseUrl && !!token
 }

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -2,18 +2,18 @@ import { getStorage } from "./browser";
 
 const CONFIG_KEY = "ld_ext_config";
 
-export async function getConfiguration() {
-  const DEFAULT_CONFIG = {
-    baseUrl: "",
-    token: "",
-    resultNum: 10,
-    openLinkType: "newTab",
-    themeGoogle: "auto",
-    themeDuckduckgo: "auto",
-    themeBrave: "auto",
-    themeSearx: "auto",
-  };
+const DEFAULT_CONFIG = {
+  baseUrl: "",
+  token: "",
+  resultNum: 10,
+  openLinkType: "newTab",
+  themeGoogle: "auto",
+  themeDuckduckgo: "auto",
+  themeBrave: "auto",
+  themeSearx: "auto",
+};
 
+export async function getConfiguration() {
   return new Promise((resolve) => {
     getStorage().get(CONFIG_KEY, (data) => {
       const config = JSON.parse(data[CONFIG_KEY] || DEFAULT_CONFIG);

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -40,6 +40,6 @@ export async function isConfigurationComplete() {
   if (config.baseUrl === "" || config.token === "") {
     return false;
   } else {
-    return true;
+    return true
   }
 }


### PR DESCRIPTION
There is a signature error  in the getConfiguration method: 

<img width="711" alt="image" src="https://github.com/Fivefold/linkding-injector/assets/91365763/179766eb-7866-45a0-98a8-7ef3b4996e5e">

```
Uncaught (in promise) TypeError: Error in invocation of storage.get(optional [string|array|object] keys, function callback): No matching signature.
    at getConfiguration (configuration.js:8:32)
    at isConfigurationComplete (linkding.js:4:4)
    at background.js:33:10
```

And this PR aims to fix it and refactor the saveConfiguration method to be cleaner.