### PR TITLE
Changing the search injection point for kagi.

### DIFF
--- a/src/searchInjection.js
+++ b/src/searchInjection.js
@@ -41,7 +41,7 @@ const sidebarSelectors = {
   google: "#rhs",
   brave: "aside.sidebar",
   searx: "#sidebar",
-  kagi: ".right-content-box",
+  kagi: ".right-content-box > ._0_right_sidebar",
   qwant: ".is-sidebar",
 };
 


### PR DESCRIPTION
Swapping from `kagi: ".right-content-box",` to `kagi: ".right-content-box > ._0_right_sidebar",` to work for a greater amount of searches (specifically ones that don't include another sidebar box)