### PR TITLE
Add meta viewport element for better scaling of options menu on mobile

### DIFF
--- a/options/index.html
+++ b/options/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Linkding Extension Options</title>
     <link rel="stylesheet" href="../styles/spectre.css">
     <link rel="stylesheet" href="../styles/spectre-icons.css">


### PR DESCRIPTION
As I said in #10 I'm working on mobile at the moment. However one thing I noticed right away, was the options not scaling properly for mobile. And I think this tiny change is good to have regardless, before I'll be ready for a whole mobile support PR.