### PR TITLE
Use hierarchy of fallback selectors for injection

### DIFF
--- a/options/index.html
+++ b/options/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Linkding Extension Options</title>
     <link rel="stylesheet" href="../styles/spectre.css">
     <link rel="stylesheet" href="../styles/spectre-icons.css">

--- a/scss/injectionBox.scss
+++ b/scss/injectionBox.scss
@@ -19,7 +19,8 @@ div#bookmark-list-container {
   }
   
   &.google { // google-specific styles
-    width: 369px;
+    min-width: 369px;
+    width: 100%;
     box-sizing: border-box;
     box-shadow: none;
 

--- a/src/searchInjection.js
+++ b/src/searchInjection.js
@@ -36,11 +36,46 @@ if (document.location.hostname.match(/duckduckgo\.com/)) {
 }
 
 /**
+ * Location of the injection
+ * @typedef {Object} InjectionLocation
+ * @property {string} className - name of the class to be applied to the injected element, based on the location
+ * @property {(element: Element, location: InjectionLocation) => void} transformation - transformation on the injected element itself
+ */
+
+/**
+ * List of the possible injection locations
+ * @type { { [key: string]: InjectionLocation } }
+ */
+const injectionLocations = {
+  sidebar: {
+    className: "location-sidebar",
+    transformation: (element, location) => {
+      element.classList.add(location.className);
+    }
+  },
+  top: {
+    className: "location-top",
+    transformation: (element, location) => {
+      element.classList.add(location.className);
+    }
+  }
+};
+
+/**
+ * @param {Element} element
+ * @param {InjectionLocation} location
+ */
+function addLocationClass(element, location) {
+  element.classList.add(location.className)
+}
+
+/**
  * Selector for the container to inject into
  * @typedef {Object} InjectionContainerQuery
- * @property {function(): void | null} transformation - transformation to apply before using the selector
+ * @property {(() => void) | null} transformation - transformation to apply before using the selector
  * @property {string} selector - the CSS selector to use for querying the container
- * @property {function(): void | null} reverseTransformation - reversion of the transformation if the selector still wasn't found
+ * @property {(() => void) | null} reverseTransformation - reversion of the transformation if the selector still wasn't found
+ * @property {InjectionLocation} location - location, where the element will be injected in
  */
 
 /**
@@ -49,15 +84,30 @@ if (document.location.hostname.match(/duckduckgo\.com/)) {
  */
 const sidebarSelectors = {
   duckduckgo: [
-    { transformation: null, selector: "section[data-area=sidebar]", reverseTransformation: null },
-    { transformation: null, selector: "section[data-area=mainline]", reverseTransformation: null }
+    {
+      transformation: null,
+      selector: "section[data-area=sidebar]",
+      reverseTransformation: null,
+      location: injectionLocations.sidebar
+    },
+    {
+      transformation: null,
+      selector: "section[data-area=mainline]",
+      reverseTransformation: null,
+      location: injectionLocations.top
+    }
   ],
   google: [
-    { transformation: null, selector: "#rhs", reverseTransformation: null },
+    {
+      transformation: null,
+      selector: "#rhs",
+      reverseTransformation: null,
+      location: injectionLocations.sidebar
+    },
     {
       // Google completely omits the sidebar container if there is no content.
       // We need to add it manually before injection
-      transformation: function() {
+      transformation: () => {
         const sidebarContainerString = `
         <div id="rhs" class="TQc1id hSOk2e rhstc4"></div>`;
 
@@ -67,27 +117,56 @@ const sidebarSelectors = {
           "text/html"
         );
         const container = document.querySelector("#rcnt");
-        container?.appendChild(sidebarContainer.body.querySelector("div"));
+        const rhsElement = sidebarContainer.body.querySelector("div#rhs");
+        if (rhsElement !== null) {
+          container?.appendChild(rhsElement);
+        }
       },
       selector: "#rhs",
-      reverseTransformation: function() {
+      reverseTransformation: () => {
         const element = document.querySelector("#rhs");
-        element?.parentElement.removeChild(element);
-      }
+        element?.parentElement?.removeChild(element);
+      },
+      location: injectionLocations.sidebar
     },
-    { transformation: null, selector: "#topstuff", reverseTransformation: null }
+    {
+      transformation: null,
+      selector: "#topstuff",
+      reverseTransformation: null,
+      location: injectionLocations.top
+    }
   ],
   brave: [
-    { transformation: null, selector: "aside.sidebar", reverseTransformation: null }
+    {
+      transformation: null,
+      selector: "aside.sidebar",
+      reverseTransformation: null,
+      location: injectionLocations.sidebar
+    }
   ],
   searx: [
-    { transformation: null, selector: "#sidebar", reverseTransformation: null }
+    {
+      transformation: null,
+      selector: "#sidebar",
+      reverseTransformation: null,
+      location: injectionLocations.sidebar
+    }
   ],
   kagi: [
-    { transformation: null, selector: ".right-content-box > ._0_right_sidebar", reverseTransformation: null }
+    {
+      transformation: null,
+      selector: ".right-content-box > ._0_right_sidebar",
+      reverseTransformation: null,
+      location: injectionLocations.sidebar
+    }
   ],
   qwant: [
-    { transformation: null, selector: ".is-sidebar", reverseTransformation: null }
+    {
+      transformation: null,
+      selector: ".is-sidebar",
+      reverseTransformation: null,
+      location: injectionLocations.sidebar
+    }
   ],
 };
 
@@ -212,14 +291,17 @@ port.onMessage.addListener(function (m) {
   // Finding the sidebar
   const sidebarSelector = sidebarSelectors[searchEngine] ?? [];
   let sidebar = null;
+  let injectionLocation = null;
 
   for (const injectionContainerQuery of sidebarSelector) {
     if (injectionContainerQuery.transformation !== null) {
       injectionContainerQuery.transformation();
     }
     sidebar = document.querySelector(injectionContainerQuery.selector);
+    const isVisible = sidebar?.checkVisibility() ?? false;
 
-    if (sidebar !== null && sidebar.checkVisibility()) {
+    if (sidebar !== null && isVisible) {
+      injectionLocation = injectionContainerQuery.location;
       break;
     }
 
@@ -232,7 +314,11 @@ port.onMessage.addListener(function (m) {
   html = parser.parseFromString(htmlString, "text/html");
   // The actual injection
   if (document.querySelector("#bookmark-list-container") == null) {
-    sidebar.prepend(html.body.querySelector("div"));
+    const injectedElement = html.body.querySelector("div#bookmark-list-container");
+    if (injectionLocation !== null && injectedElement !== null) {
+      injectionLocation.transformation(injectedElement, injectionLocation);
+      sidebar?.prepend(injectedElement);
+    }
   }
 
   // Event listeners for opening the extension options. These can only be opened
@@ -262,7 +348,8 @@ if (searchEngine == "brave") {
   // Qwant asynchronously loads the sidebar. We need to watch for when the
   // sidebar is loaded and only then start the injection
   const qwantObserver = new MutationObserver((mutations, observer) => {
-    if (document.querySelector(sidebarSelectors["qwant"])) {
+    // TODO: just using the first element of the array doesn't seem like a good idea
+    if (document.querySelector(sidebarSelectors["qwant"][0].selector)) {
       port.postMessage({ searchTerm: searchTerm });
       observer.disconnect(); // Stop observing after the element appears
     }

--- a/src/searchInjection.js
+++ b/src/searchInjection.js
@@ -35,14 +35,60 @@ if (document.location.hostname.match(/duckduckgo\.com/)) {
   console.debug("Linkding-Injector extension: unknown search engine.");
 }
 
-// CSS selectors for finding the sidebar to later inject into
+/**
+ * Selector for the container to inject into
+ * @typedef {Object} InjectionContainerQuery
+ * @property {function(): void | null} transformation - transformation to apply before using the selector
+ * @property {string} selector - the CSS selector to use for querying the container
+ * @property {function(): void | null} reverseTransformation - reversion of the transformation if the selector still wasn't found
+ */
+
+/**
+ * CSS selectors for finding the sidebar to later inject into
+ * @type { { [key: string]: Array.<InjectionContainerQuery> } }
+ */
 const sidebarSelectors = {
-  duckduckgo: "section[data-area=sidebar]",
-  google: "#rhs",
-  brave: "aside.sidebar",
-  searx: "#sidebar",
-  kagi: ".right-content-box > ._0_right_sidebar",
-  qwant: ".is-sidebar",
+  duckduckgo: [
+    { transformation: null, selector: "section[data-area=sidebar]", reverseTransformation: null },
+    { transformation: null, selector: "section[data-area=mainline]", reverseTransformation: null }
+  ],
+  google: [
+    { transformation: null, selector: "#rhs", reverseTransformation: null },
+    {
+      // Google completely omits the sidebar container if there is no content.
+      // We need to add it manually before injection
+      transformation: function() {
+        const sidebarContainerString = `
+        <div id="rhs" class="TQc1id hSOk2e rhstc4"></div>`;
+
+        const parser = new DOMParser();
+        const sidebarContainer = parser.parseFromString(
+          sidebarContainerString,
+          "text/html"
+        );
+        const container = document.querySelector("#rcnt");
+        container?.appendChild(sidebarContainer.body.querySelector("div"));
+      },
+      selector: "#rhs",
+      reverseTransformation: function() {
+        const element = document.querySelector("#rhs");
+        element?.parentElement.removeChild(element);
+      }
+    },
+    { transformation: null, selector: "#topstuff", reverseTransformation: null }
+  ],
+  brave: [
+    { transformation: null, selector: "aside.sidebar", reverseTransformation: null }
+  ],
+  searx: [
+    { transformation: null, selector: "#sidebar", reverseTransformation: null }
+  ],
+  kagi: [
+    { transformation: null, selector: ".right-content-box > ._0_right_sidebar", reverseTransformation: null }
+  ],
+  qwant: [
+    { transformation: null, selector: ".is-sidebar", reverseTransformation: null }
+  ],
 };
 
 // When background script answers with results, construct html for the result box
@@ -164,21 +210,22 @@ port.onMessage.addListener(function (m) {
   }
 
   // Finding the sidebar
-  const sidebarSelector = sidebarSelectors[searchEngine];
-  let sidebar = document.querySelector(sidebarSelector);
+  const sidebarSelector = sidebarSelectors[searchEngine] ?? [];
+  let sidebar = null;
 
-  // Google completely omits the sidebar container if there is no content.
-  // We need to add it manually before injection
-  if (searchEngine === "google" && sidebar === null) {
-    let sidebarContainerString = `
-    <div id="rhs" class="TQc1id hSOk2e rhstc4"></div>`;
-    let sidebarContainer = parser.parseFromString(
-      sidebarContainerString,
-      "text/html"
-    );
-    let container = document.querySelector("#rcnt");
-    container.appendChild(sidebarContainer.body.querySelector("div"));
-    sidebar = document.querySelector("#rhs");
+  for (const injectionContainerQuery of sidebarSelector) {
+    if (injectionContainerQuery.transformation !== null) {
+      injectionContainerQuery.transformation();
+    }
+    sidebar = document.querySelector(injectionContainerQuery.selector);
+
+    if (sidebar !== null && sidebar.checkVisibility()) {
+      break;
+    }
+
+    if(injectionContainerQuery.reverseTransformation !== null) {
+      injectionContainerQuery.reverseTransformation();
+    }
   }
 
   // Convert the html string into a DOM document


### PR DESCRIPTION
To get mobile working as requested in #10 I've decided to not go the route of having mobile-specific code but the possibility to have a viable list of selectors for each search engine, with optional transformations before (and after failed query for the element).
Also, instead of just checking if the element is null, I also check if it is visible or not.

This maps nicely with the special-case Google had already.

What it also allows, is adding mobile support on-demand, when someone has the time to figure out how to do it for a certain search engine, as I'm not sure if I'll find the time to do it for all. Also might not find the time for looking at styling issues very much right now, as it doesn't look that pretty on mobile.

However, it can serve as a baseline, with some form of mobile "support" already (it's visible without desktop mode at least), which is a good first step I think.

Please let me know, what you think of this approach.
